### PR TITLE
Fix user id for group chat.

### DIFF
--- a/src/BotFrameworkDriver.php
+++ b/src/BotFrameworkDriver.php
@@ -98,7 +98,7 @@ class BotFrameworkDriver extends HttpDriver
      */
     public function getUser(IncomingMessage $matchingMessage)
     {
-        return new User($matchingMessage->getRecipient(), null, null,
+        return new User($matchingMessage->getSender(), null, null,
             Collection::make($matchingMessage->getPayload())->get('from')['name']);
     }
 


### PR DESCRIPTION
I am suggesting to use getSender() instead of getRecipient() to set the user ID because getSender() will always have the user ID while getRecipient() has the conversation ID in case of group chat.