### PR TITLE
fix for ms bot framework emulator not responding

### DIFF
--- a/src/BotFrameworkDriver.php
+++ b/src/BotFrameworkDriver.php
@@ -192,7 +192,7 @@ class BotFrameworkDriver extends HttpDriver
         $this->apiURL = Collection::make($payload)->get('serviceUrl',
                 Collection::make($additionalParameters)->get('serviceUrl')).'/v3/conversations/'.urlencode($recipient).'/activities';
 
-        if (strstr($this->apiURL, 'webchat.botframework')) {
+        if (strstr($this->apiURL, 'webchat.botframework') || stripos($this->apiURL,'http://localhost')===0) {
             $parameters['from'] = [
                 'id' => $payload['recipient']['id'],
             ];


### PR DESCRIPTION
As [bot emulator ](https://github.com/microsoft/BotFramework-Emulator) only works on localhost this is needed for it to respond to messages