### PR TITLE
fix for removing botname from received text

### DIFF
--- a/src/BotFrameworkDriver.php
+++ b/src/BotFrameworkDriver.php
@@ -72,7 +72,13 @@ class BotFrameworkDriver extends HttpDriver
     {
         // replace bot's name for group chats and special characters that might be sent from Web Skype
         $pattern = '/<at id=(.*?)at>[^(\x20-\x7F)\x0A]*\s*/';
-        $message = preg_replace($pattern, '', $this->event->get('text'));
+        $channelData = $this->event->get('channelData',[]);
+        if (isset($channelData['text'])) {
+                $message = preg_replace($pattern, '', $channelData['text']);
+        } else {
+                $message = preg_replace($pattern, '', $this->event->get('text'));
+        }
+
 
         if (empty($this->messages)) {
             $this->messages = [


### PR DESCRIPTION
In Bot Framework SDK v4 and skype groupchat at least
"channelData->text" holds the raw message and is escaped correclty
"text" is already filtered, but still contains @ botname
so can not be used

Probably will fix #13 and #10