### PR TITLE
fix issue that every message is seen has as message with attachment

### DIFF
--- a/src/BotFrameworkDriver.php
+++ b/src/BotFrameworkDriver.php
@@ -40,7 +40,9 @@ class BotFrameworkDriver extends HttpDriver
      */
     public function matchesRequest()
     {
-        $noAttachments = Collection::make($this->event->get('attachments'))->isEmpty();
+        $noAttachments = Collection::make($this->event->get('attachments'))->filter(function($item) {
+            return strtolower($item['contentType']) != 'text/html';
+        })->count() == 0;
 
         return $noAttachments && (! is_null($this->event->get('recipient')) && ! is_null($this->event->get('serviceUrl')));
     }


### PR DESCRIPTION
With the v4.0 SDK, every message is also included as a html tag in tag "attachments" array item.
Without this change no message from MS teams is seen as a normal message thus `hears()` will not work.